### PR TITLE
Add script to migrate AD groups to M365

### DIFF
--- a/MigrateADGroups.ps1
+++ b/MigrateADGroups.ps1
@@ -1,475 +1,124 @@
-﻿[CmdletBinding()]
-param(
-    [Parameter(Mandatory=$true,Position=0,ValueFromPipeline,ValueFromPipelineByPropertyName,HelpMessage="Enter the OU that you want to process in double quotes")]
-    [Alias("DistinguishedName")]
-    [string]$OrgUnit,
-    [Parameter(Mandatory=$true,Position=1,ValueFromPipeline,HelpMessage="Enter Universal, DomainLocal, or Global with NO double quotes")]
-    [ValidateSet("Universal","DomainLocal","Global")]
-    [string]$GroupScope,
-    [Parameter()]
-    [bool]$SavetoFile
+<#
+.SYNOPSIS
+Migrates Active Directory groups to Microsoft 365.
 
+.DESCRIPTION
+The script exports the on-premises AD groups and their members from the
+specified OU, backs up any existing Microsoft 365 groups with matching
+names, creates the groups in Microsoft 365 if they do not exist, and adds
+all members to the cloud groups. Backups are written to a local Backups
+folder in the script directory.
+
+.EXAMPLE
+./MigrateADGroups.ps1 -OrgUnit "OU=Groups,DC=contoso,DC=com" -GroupScope Universal
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$OrgUnit,
+
+    [Parameter(Mandatory)]
+    [ValidateSet('Universal','Global','DomainLocal')]
+    [string]$GroupScope,
+
+    [switch]$WhatIf
 )
 
-# Create temp folder for logs
-if (!(Test-Path -Path "$env:TEMP\MigrateADGroups")){
-
-    New-Item -Path "$env:TEMP" -ItemType Directory -Name "MigrateADGroups"
-}
-
-# Serializing the parameter values to be used in new pwoershell instances
-    $ParentInstanceValues = @{
-    OrgUnit = $OrgUnit
-    GroupScope = $GroupScope
-    SavetoFile = $SavetoFile
-}
-
-$ParentInstanceValues | ConvertTo-Json -Depth 3 | Set-Content "$env:TEMP\MigrateADGroups\ParameterValues.json"
-
-
-# Elevating to administrator if not running as administrator   
-if (-not [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)) {
-    Write-Host "Process requires elevated rights...`n`tElevating to administrator..."
-
-    Start-Process -FilePath "powershell.exe" -ArgumentList @(
-    "-File", "`"$PSCommandPath`"",
-    "-OrgUnit", "`"$($OrgUnit)`"",
-    "-GroupScope", "$GroupScope"
-) -Verb RunAs
-Stop-Process $PID
-
-}
-
-
-
-
-#Global Variables
-$Global:LogPath = "$env:TEMP\MigrateADGroups\"
-$global:TimeStamp = (Get-Date).ToString("MM/dd/yyyy HH:mm:ss")
-
-
-
-# Logs to console and to file
-function New-MigrationLog {
+function Get-ADGroupsWithMembers {
     param(
-        [Logs]$Type,
-        [string]$Message
+        [string]$SearchBase,
+        [string]$Scope
     )
-
-    enum Logs {
-        Info
-        Success
-        Error
-    }
-
-    $FileLocation = "$global:Logpath\Migration-Log.txt"
-    
-
-    $console_logs = @{
-        Info = "$($timestamp) : Line : $($MyInvocation.ScriptLineNumber) : $($message)"
-        Success = "$($timestamp) : Line : $($MyInvocation.ScriptLineNumber) : $($message)"
-        Error = "$($timestamp) : ERROR: An error occurred at Line: $($MyInvocation.ScriptLineNumber) with the following error message: `n$($Error[0])"
-    }
-
-    switch ($Type) {
-        ([Logs]::Info) {$console_logs.Info | Tee-Object -FilePath $FileLocation -Append ; break}
-        ([Logs]::Success) {$console_logs.Success | Tee-Object -FilePath $FileLocation -Append ; break }
-        ([Logs]::Error) {$console_logs.Error | Tee-Object -FilePath $FileLocation -Append; break} 
-
+    $groups = Get-ADGroup -SearchBase $SearchBase -SearchScope Subtree -GroupScope $Scope -ErrorAction Stop
+    foreach ($g in $groups) {
+        $members = Get-ADGroupMember -Identity $g -Recursive -ErrorAction SilentlyContinue |
+            Where-Object { $_.ObjectClass -eq 'user' }
+        [pscustomobject]@{
+            Group          = $g
+            Name           = $g.Name
+            SamAccountName = $g.SamAccountName
+            Members        = $members
+        }
     }
 }
 
-
-# Stops stript execution and logs to console and file
-function Stop-ScriptExecution {
-    param (
-        [switch]$ExitScript
-    
-    )
-    $LogPath = "$env:TEMP\MigrateADGroups\Migration-Log.txt"
-    $Failure =  "$($timestamp) : FAILURE: Script Halted at Line: $($MyInvocation.ScriptLineNumber) "
-
-    if ($ExitScript){ 
-
-        throw "$message`n  `n$($Failure)"  | Tee-Object -FilePath $LogPath -Append
-    }
-}
-
-# Create a file based checkpoint
-function New-ScriptCheckpoint {
-    [CmdletBinding()]
-    Param(
-        [Parameter()]
-        [string]$FileName
-    )
-    $CheckPointLocation = "$env:TEMP\MigrateADGroups\"
-
-    if ($FileName) {
-
-        New-Item -Path $CheckPointLocation -ItemType File -Name $FileName
-
-        New-MigrationLog -Type info -Message "$($FileName) has been created at: $($CheckPointLocation)"
-    }
-
-
-}   
-
-
-
-# Checks for a file based checkpoint
-function Get-ScriptCheckpoint {
-    [CmdletBinding()]
+function Export-GroupBackup {
     param(
-        [Parameter()]
-        [string]$FileName
+        [string]$Path,
+        [array]$Groups
     )
-    $CheckPointLocation = "$env:TEMP\MigrateADGroups\"
-
-    if ($FileName) {
-
-        if (Get-ChildItem -Path $CheckPointLocation -Name $FileName -ErrorAction SilentlyContinue)  {
-            return "Exists"
-        }
-        else {
-            return "Not Exists"
-        }
-    }
-  
-}   
-
-# Takes [string] for the OU and gets the groups and members of the OU, returns [pscustomobject]
-function Get-TargetADGroups {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true,Position=0,ValueFromPipeline,ValueFromPipelineByPropertyName)]
-        [Alias("DistinguishedName")]
-        [string]$OrgUnit,
-
-        [Parameter(Mandatory = $true,Position=1)]
-        [string]$GroupScope,
-
-        [Parameter()]
-        [switch]$SavetoFile
-    )
-
-    if ($OrgUnit -notmatch "^OU=.+m=,") {
-
-        $DistinguishedName = (Get-ADOrganizationalUnit -Filter "Name -eq '$($OrgUnit)'").distinguishedname 
-
-        $DistinguishedName.DistinguishedName
-    }
-    $TargetGroups = Get-ADGroup -Filter "GroupScope -eq '$($GroupScope)'" -SearchBase ($DistinguishedName) -Property Mail | Select-Object Name, Mail
-
-    $Groups = @()
-
-    foreach ($Group in $TargetGroups) {
-
-        $GroupMembers = Get-ADGroupMember -Identity $Group.Name | Where-Object { $_.ObjectClass -eq "User" }
-
-        foreach ($Member in $GroupMembers) {
-
-
-            $Users = Get-ADUser -Identity $Member.SamAccountName -Properties Name, Mail
-            
-            foreach ($User in $Users) {
-        
-            $GroupObject = New-Object PSObject -Property @{
-            "GroupName" = $Group.Name
-            "GroupEmail" = $Group.Mail
-            "UserName" = $User.Name 
-            "UserEmail" = $User.Mail # TODO Write in error handling at some point to handle users without email in the email field.
-                }
-                $Groups += $GroupObject
+    $Groups | ForEach-Object {
+        foreach ($m in $_.Members) {
+            [pscustomobject]@{
+                GroupName              = $_.Name
+                MemberSamAccountName   = $m.SamAccountName
+                MemberUserPrincipalName = $m.UserPrincipalName
             }
-            
         }
-    }
-
-    $PreMigrationReport = "$Global:LogPath\PreMigrationReport_ADGroups.csv"
-
-    if ($SavetoFile){
-
-        $Groups | Export-Csv -Path $PreMigrationReport -NoTypeInformation
-
-    }
-
-    return $Groups
+    } | Export-Csv -Path $Path -NoTypeInformation -Encoding UTF8
 }
 
-# Takes  [pscustomobject] from Get-TargetADGroups and queries Excahnge Online for the groups and members in the cloud
-function Get-CloudGroups {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory=$true,Position=0,ValueFromPipeline)]
-        [PSCustomObject]$InputObject,
-        [Parameter()]
-        [switch]$SavetoFile
-    )
+function Get-M365GroupByName {
+    param([string]$Name)
+    Get-MgGroup -Filter "displayName eq '$Name'"
+}
 
-    Begin {
-    $CloudGroups = @()
+function Ensure-M365Group {
+    param([pscustomobject]$ADGroup)
+    $cloudGroup = Get-M365GroupByName -Name $ADGroup.Name
+    if (-not $cloudGroup) {
+        $params = @{
+            DisplayName     = $ADGroup.Name
+            MailEnabled     = $false
+            MailNickname    = $ADGroup.SamAccountName
+            SecurityEnabled = $true
+        }
+        if (-not $WhatIf) {
+            $cloudGroup = New-MgGroup @params
+        } else {
+            Write-Host "WhatIf: would create group $($ADGroup.Name)"
+        }
     }
+    $cloudGroup
+}
 
-    Process {
-        foreach($Object in $InputObject) {
-        $TargetGroup = Get-DistributionGroup -Identity $InputObject.GroupEmail
-
-            foreach ($Group in $TargetGroup){
-
-                $GroupMembers = Get-DistributionGroupMember -Identity $TargetGroup.Identity
-    
-                    foreach ($User in ($GroupMembers)){
-                        $CloudGroups += New-Object PSObject -Property @{
-                            "GroupDisplayName" = $InputObject.GroupName
-                            "GroupEmail" = $InputObject.GroupEmail
-                            "UserDisplayName" = $User.DisplayName
-                            "UserEmail" = $User.PrimarySmtpAddress
-                
-                }
+function Sync-Members {
+    param(
+        [Microsoft.Graph.PowerShell.Models.IMicrosoftGraphGroup]$CloudGroup,
+        [array]$Members
+    )
+    foreach ($m in $Members) {
+        $user = Get-MgUser -Filter "userPrincipalName eq '$($m.UserPrincipalName)'"
+        if ($user) {
+            if (-not $WhatIf) {
+                New-MgGroupMember -GroupId $CloudGroup.Id -DirectoryObjectId $user.Id -ErrorAction SilentlyContinue
+            } else {
+                Write-Host "WhatIf: would add $($m.UserPrincipalName) to $($CloudGroup.DisplayName)"
             }
         }
     }
 }
-    End {
 
-        $PreCloudGroupRemovalReport = "$Global:LogPath\PreCloudRemovalReport_M365Groups.csv"
+Import-Module ActiveDirectory -ErrorAction Stop
+Import-Module Microsoft.Graph.Groups
+Import-Module Microsoft.Graph.Users
+Connect-MgGraph -Scopes "Group.ReadWrite.All","User.Read.All" | Out-Null
 
-        if ($SavetoFile){
-                $CloudGroups | Export-Csv -Path $PreCloudGroupRemovalReport -NoTypeInformation
-            }
-    
-    return $CloudGroups
+$backupRoot = Join-Path $PSScriptRoot 'Backups'
+if (-not (Test-Path $backupRoot)) { New-Item -ItemType Directory -Path $backupRoot | Out-Null }
+
+$adGroups = Get-ADGroupsWithMembers -SearchBase $OrgUnit -Scope $GroupScope
+Export-GroupBackup -Path (Join-Path $backupRoot 'ADGroups.csv') -Groups $adGroups
+
+$cloudGroups = foreach ($g in $adGroups) { Get-M365GroupByName -Name $g.Name }
+$cloudGroups | Export-Csv -Path (Join-Path $backupRoot 'M365Groups.csv') -NoTypeInformation -Encoding UTF8
+
+foreach ($g in $adGroups) {
+    $target = Ensure-M365Group -ADGroup $g
+    if ($target) {
+        Sync-Members -CloudGroup $target -Members $g.Members
     }
 }
 
-function Remove-CloudGroups {
-            [CmdletBinding(DefaultParameterSetName = "Remove")]
-    param (
-        [Parameter(Mandatory = $true, ParameterSetName = "Remove")]
-        [switch]$Remove,
-        [Parameter(Mandatory = $true, ParameterSetName = "Remove")]
-        [string]$GroupID
-
-
-    )
-
-    foreach ($ID in $GroupID) {
-
-        Remove-MgGroup -GroupID $ID
-
-    }
-
-}
-
-function New-CloudGroups{
-        [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true)]
-        [string]$GroupID
-
-    )
-
-}
-function Restart-ScriptSession
-{
-    # [CmdletBinding()]
-    # Param(
-    #     [Parameter(Mandatory=$true)]
-    #     [string]$OrgUnit,
-    #     [Parameter(Mandatory=$true)]
-    #     [ValidateSet("Universal", "DomainLocal", "Global")]
-    #     [string]$GroupScope,
-    #     [Parameter()]
-    #     [bool]$SavetoFile = $false
-    # )
-
-    # -OrgUnit $($OrgUnit.Trim()) -GroupScope $($GroupScope) -SavetoFile $($SavetoFile) 
-Start-Process -FilePath "powershell.exe" -ArgumentList @(
-    "-File", "`"$PSCommandPath`"",
-    "-OrgUnit", "`"$OrgUnit`"",
-    "-GroupScope", "`"$GroupScope`""
-) -WindowStyle Normal
-
-Stop-Process $PID
-
-}
-
-
-
-######
-## START SCRIPT
-######
-
-# Checkpoint Switch 
-pause 
-Write-Host "305"
-$IsFileExists = Get-ScriptCheckpoint -FileName "CheckPoint_1"
-# TODO get switch working
-
-
-if (($IsFileExists -eq "Not Exists")){
-
-     New-MigrationLog -Type Info -Message "Checking execution policy..."
-
-    if ((Get-ExecutionPolicy -Scope Process) -notin @("Bypass", "Unrestricted") -and (Get-ExecutionPolicy) -ne "Unrestricted") {
-        New-MigrationLog -Type Info -Message "Policy current set to [$(Get-ExecutionPolicy -Scope Process)]. Bypass or Unrestricted required: Restarting script."
-    }
-
-Write-Host "Line 305"
-Pause
-
-    New-MigrationLog -Type Info -Message "Valid execution policy set"
-
-    # Install Excahnge Online module
-
-    New-MigrationLog -Type Info -Message "Verifying Exchange module is installed..." 
-Write-Host "Pause 2"
-
-    if (-not (Get-Module -ListAvailable ExchangeOnlineManagement))
-    {  
-        New-MigrationLog -Type info  -Message "Missing Exchange module Installing module..."
-
-    try {
-
-        New-MigrationLog -Type info  -Message "Checking for Nuget and installing if needed"
-    
-        if (-not (Get-PackageProvider -Name Nuget -ListAvailable  -ErrorAction SilentlyContinue)) {
-
-            Install-PackageProvider -Name Nuget -Force
-        }
-    
-    } catch {
-
-        New-MigrationLog -type Error
-        # Stop-ScriptExecution -ExitScript
-
-    }
-Write-Host "Line 334"
-Pause
-    try{
-        Install-Module -Name ExchangeOnlineManagement -Force
-
-        New-MigrationLog -Type info  -Message "ExchangeOnlineManagement Module installed"
-    } catch {
-
-        New-MigrationLog -type Error
-        Stop-ScriptExecution -ExitScript
-    }
-
-
-    New-MigrationLog -Info -Message "Generating checkpoint at: $($Global:LogPath)"
-    New-ScriptCheckpoint -FileName "CheckPoint_1"
-
-Write-Host "Line 345"
-
-    New-MigrationLog -Type Info -message  "Script is restarting" 
-    try {
-        if (Get-ScriptCheckpoint -FileName "Checkpoint_1"){
-            Start-Process -FilePath "powershell.exe" -ArgumentList @(
-                "-File", "`"$PSCommandPath`""
-                "-OrgUnit", "`"$OrgUnit`"",
-                "-GroupScope", "`"$GroupScope`"",
-                "-SavetoFile", "`"$SavetoFile`""
-
-            ) -WindowStyle Normal
-
-            
-        }
-        Stop-Process $PID
-    }
-    catch {
-        
-        New-MigrationLog -type Error
-    }
-    }
-}
-elseif ($IsFileExists -eq "Exists") {
-        New-MigrationLog -Type Info -Message "Importing module: [ExchangeOnlineManagement]"
-        New-MigrationLog -Type Info -message "Importing Module after restart"
-
-    Pause
-    # Derializing the parameter values to be used in new pwoershell instances
-    # Serialization is at the beginning of this script
-        $JSONValues = @{
-        $ParentInstanceValues=  Get-Content -Path "$env:TEMP\MigrateADGroups\ParameterValues.json" | ConvertFrom-Json  
-        OrgUnit = $ParentInstanceValues.OrgUnit
-        GroupScope = $ParentInstanceValues.GroupScope
-        SavetoFile = $ParentInstanceValues.SavetoFile
-    }
-
-    $JSONValues.OrgUnit
-    $JSONValues.GroupScope
-    $JSONValues.SavetoFile
-
-    Import-Module -Name ExchangeOnlineManagement -Verbose
-
-Write-Host "Line 369"
-Pause
-    # Everything below this comment should start in a new session
-
-    New-MigrationLog -Info -Message "Connecting to Exchange Online..."
-
-    Connect-ExchangeOnline
-
-    New-MigrationLog -Type Info -Message "Starting Active Directory group migration"
-
-    New-MigrationLog -Type Info -Message "Getting AD groups and group members from: $($OrgUnit)"
-
-    #$OrgUnit, $GroupScope = $OrgUnit, $GroupScope
-
-    # Gather backup reports
-    Get-TargetADGroups -OrgUnit $JSONValues.OrgUnit -GroupScope $JSONValues.GroupScope -SavetoFile $JSONValues.SavetoFile
-    $CloudGroups = Get-TargetADGroups -OrgUnit $JSONValues.OrgUnit.Trim('"') -GroupScope $JSONValues.GroupScope -SavetoFile $JSONValues.SavetoFile
-    $CloudGroups
-    Pause
-
-    # Verify backup reports
-    if (!(Test-Path -Path "$Global:LogPath\PreMigrationADGroups_Backup.csv")){
-
-    try {
-    
-        Get-TargetADGroups -OrgUnit $JSONValues.OrgUnit -GroupScope $JSONValues.GroupScope -SavetoFile $JSONValues.SavetoFile
-
-        if (Test-Path -Path "$Global:LogPath\PreMigrationADGroups_Backup.csv"){
-
-            New-MigrationLog -Type Info -message "AD Groups with Users has been backed up to $("$Global:LogPath\PreMigrationADGroups_Backup.csv")" 
-        }
-    }
-    catch {
-
-        New-MigrationLog -Type Error
-    }
-
-} else{
-
-    New-MigrationLog -Type Success -Message "AD Groups with Users has been backed up to $("$Global:LogPath\PreMigrationADGroups_Backup.csv")"
-
-}
-
-if (!(Test-Path -Path "$Global:LogPath\PreMigrationCloudGroups_Backup.csv")){
-
-    try {   
-
-        $CloudGroups | Where-Object {$_ -ne $null} | Get-CloudGroups 
-
-         if (Test-Path -Path ("$Global:LogPath\PreMigrationCloudGroups_Backup.csv")){
-            
-            New-MigrationLog -Type Info -message "AD Groups with Users has been backed up to $("$Global:LogPath\PreMigrationCloudGroups_Backup.csv")"
-        }
-    }
-    catch {
-
-        New-MigrationLog -Type Error
-    }
-} else{
-
-    New-MigrationLog -Type Success -Message "Cloud Groups with Users has been backed up to $("$Global:LogPath\PreMigrationCloudGroups_Backup.csv")"
-}
-
-}
-
-
-
-
-
-
+Write-Host "Migration complete. Backups stored in $backupRoot"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Migrate AD Groups to M365
-Powershell script to migrate AD groups to M365
 
+PowerShell script to migrate Active Directory groups and their members to Microsoft 365.
 
-# Work in Progress
+The script exports on-premises groups and their membership, backs up any existing cloud groups,
+creates missing groups in Microsoft 365, and adds members to the corresponding cloud groups.
+Backups are stored in a `Backups` folder next to the script.
+
+## Usage
+
+```powershell
+./MigrateADGroups.ps1 -OrgUnit "OU=Groups,DC=contoso,DC=com" -GroupScope Universal
+```
+
+Requires the **ActiveDirectory** module for on-premises queries and the
+**Microsoft.Graph** modules for cloud operations. Run with appropriate administrative
+permissions and connectivity to both environments.


### PR DESCRIPTION
## Summary
- Add PowerShell script that exports AD groups, backs up existing Microsoft 365 groups, and recreates them in the cloud with members.
- Document script usage and prerequisites in README.

## Testing
- `pwsh -NoProfile -Command "./MigrateADGroups.ps1 -OrgUnit 'OU=Test,DC=contoso,DC=com' -GroupScope Universal -WhatIf"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y powershell` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68957a21fe30833398d95bfe7e052611